### PR TITLE
Fix issue with symbolic links to binaries

### DIFF
--- a/usr/lib/uwtwrapper
+++ b/usr/lib/uwtwrapper
@@ -153,6 +153,21 @@ variables() {
    ## uwtwrapper_parent example:
    ## /usr/bin/gpg2
 
+   ## Let's see if $uwtwrapper_parent
+   ## (for example /usr/bin/git-receive-pack) is actually a symlink.
+   if test -h "$uwtwrapper_parent" ; then
+      ## Yes, it's a symlink.
+      local readlink_result
+      if readlink_result="$(readlink "$uwtwrapper_parent")" ; then
+         ## Determine if $uwtwrapper_parent does not have a wrapper script
+         if [ ! -e "$uwtwrapper_parent.anondist" ]; then
+            ## readlink_result example:
+            ## git
+            exec "$readlink_result" "$@"
+         fi
+      fi
+   fi
+
    ## Let's see if $uwtwrapper_parent.anondist-orig
    ## (for example /usr/bin/gpg2.anondist-orig) is actually a symlink.
    if test -h "$uwtwrapper_parent.anondist-orig" ; then


### PR DESCRIPTION
This is my attempt at fixing [T797](https://phabricator.whonix.org/T797). I'm certain there's a more elegant way to approach this, but this fixes the issue.

The initial test to see if `$uwtwrapper_parent` might not be needed, but I'm not certain. The check for `$uwtwrapper_parent.anondist` is to prevent an infinite loop from occurring. For example, `apt-get` would trigger it, and it would exec uwtwrapper again, `apt-get` would trigger it, etc. Since `apt-get.anondist` exists, this check prevents that from occurring.